### PR TITLE
Update client.js: Refractor on connect callback

### DIFF
--- a/client.js
+++ b/client.js
@@ -128,7 +128,7 @@ define(function()
       socket.onmessage = function(event)
       {
         var dto = JSON.parse(event.data);
-        dto.event != 'pong' && debug('socket recived message', dto);
+        debug('socket recived message', dto);
         face.trigger(dto.event, dto.data);
       };
     });


### PR DESCRIPTION
Moved onConnect callback as part of the config instead of a param.
Added onReconnect callback as part of the config
Added param to connect function to note if its part of a reconnection (It will be true if the connection have never been successfull, just notes that is not the first connection try).